### PR TITLE
feat: Pruning and compaction port to 0.38

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1151,6 +1151,22 @@ type StorageConfig struct {
 	DiscardABCIResponses bool `mapstructure:"discard_abci_responses"`
 	// Configuration related to storage pruning.
 	Pruning *PruningConfig `mapstructure:"pruning"`
+
+	// Compaction on pruning - enable or disable in-process compaction.
+	// If the DB backend supports it, this will force the DB to compact
+	// the database levels and save on storage space. Setting this to true
+	// is most beneficial when used in combination with pruning as it will
+	// phyisically delete the entries marked for deletion.
+	// false by default (forcing compaction is disabled).
+	Compact bool `mapstructure:"compact"`
+	// Compaction interval - number of blocks to try explicit compaction on.
+	// This parameter should be tuned depending on the number of items
+	// you expect to delete between two calls to forced compaction.
+	// If your retain height is 1 block, it is too much of an overhead
+	// to try compaction every block. But it should also not be a very
+	// large multiple of your retain height as it might occur bigger overheads.
+	// 1000 by default.
+	CompactionInterval int64 `mapstructure:"compaction_interval"`
 }
 
 // DefaultStorageConfig returns the default configuration options relating to
@@ -1159,6 +1175,8 @@ func DefaultStorageConfig() *StorageConfig {
 	return &StorageConfig{
 		DiscardABCIResponses: false,
 		Pruning:              DefaultPruningConfig(),
+		Compact:              false,
+		CompactionInterval:   1000,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -521,6 +521,18 @@ peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 # reindex events in the command-line tool.
 discard_abci_responses = {{ .Storage.DiscardABCIResponses}}
 
+# If set to true, CometBFT will force compaction to happen for databases that support this feature.
+# and save on storage space. Setting this to true is most benefits when used in combination
+# with pruning as it will phyisically delete the entries marked for deletion.
+# false by default (forcing compaction is disabled).
+compact = false
+# To avoid forcing compaction every time, this parameter instructs CometBFT to wait 
+# the given amount of blocks to be pruned before triggering compaction.
+# It should be tuned depending on the number of items. If your retain height is 1 block,
+# it is too much of an overhead to try compaction every block. But it should also not be a very
+# large multiple of your retain height as it might occur bigger overheads.
+compaction_interval = 1000
+
 [storage.pruning]
 
 # The time period between automated background pruning operations.

--- a/node/setup.go
+++ b/node/setup.go
@@ -110,7 +110,7 @@ func initDBs(config *cfg.Config, dbProvider cfg.DBProvider) (blockStore *store.B
 	if err != nil {
 		return
 	}
-	blockStore = store.NewBlockStore(blockStoreDB)
+	blockStore = store.NewBlockStore(blockStoreDB, store.WithCompaction(config.Storage.Compact, config.Storage.CompactionInterval))
 
 	stateDB, err = dbProvider(&cfg.DBContext{ID: "state", Config: config})
 	if err != nil {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -41,7 +41,7 @@ func ValidateValidatorUpdates(abciUpdates []abci.ValidatorUpdate, params types.V
 // SaveValidatorsInfo is an alias for the private saveValidatorsInfo method in
 // store.go, exported exclusively and explicitly for testing.
 func SaveValidatorsInfo(db dbm.DB, height, lastHeightChanged int64, valSet *types.ValidatorSet) error {
-	stateStore := dbStore{db, StoreOptions{DiscardABCIResponses: false}}
+	stateStore := dbStore{db, StoreOptions{DiscardABCIResponses: false}, StoreStateKeeper{}}
 	batch := stateStore.db.NewBatch()
 	err := stateStore.saveValidatorsInfo(height, lastHeightChanged, valSet, batch)
 	if err != nil {

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -366,9 +366,9 @@ func (_m *Store) LoadValidators(height int64) (*types.ValidatorSet, error) {
 	return r0, r1
 }
 
-// PruneABCIResponses provides a mock function with given fields: targetRetainHeight
-func (_m *Store) PruneABCIResponses(targetRetainHeight int64) (int64, int64, error) {
-	ret := _m.Called(targetRetainHeight)
+// PruneABCIResponses provides a mock function with given fields: targetRetainHeight, forceCompact
+func (_m *Store) PruneABCIResponses(targetRetainHeight int64, forceCompact bool) (int64, int64, error) {
+	ret := _m.Called(targetRetainHeight, forceCompact)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PruneABCIResponses")
@@ -377,23 +377,23 @@ func (_m *Store) PruneABCIResponses(targetRetainHeight int64) (int64, int64, err
 	var r0 int64
 	var r1 int64
 	var r2 error
-	if rf, ok := ret.Get(0).(func(int64) (int64, int64, error)); ok {
-		return rf(targetRetainHeight)
+	if rf, ok := ret.Get(0).(func(int64, bool) (int64, int64, error)); ok {
+		return rf(targetRetainHeight, forceCompact)
 	}
-	if rf, ok := ret.Get(0).(func(int64) int64); ok {
-		r0 = rf(targetRetainHeight)
+	if rf, ok := ret.Get(0).(func(int64, bool) int64); ok {
+		r0 = rf(targetRetainHeight, forceCompact)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64) int64); ok {
-		r1 = rf(targetRetainHeight)
+	if rf, ok := ret.Get(1).(func(int64, bool) int64); ok {
+		r1 = rf(targetRetainHeight, forceCompact)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
 
-	if rf, ok := ret.Get(2).(func(int64) error); ok {
-		r2 = rf(targetRetainHeight)
+	if rf, ok := ret.Get(2).(func(int64, bool) error); ok {
+		r2 = rf(targetRetainHeight, forceCompact)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -401,22 +401,32 @@ func (_m *Store) PruneABCIResponses(targetRetainHeight int64) (int64, int64, err
 	return r0, r1, r2
 }
 
-// PruneStates provides a mock function with given fields: fromHeight, toHeight, evidenceThresholdHeight
-func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThresholdHeight int64) error {
-	ret := _m.Called(fromHeight, toHeight, evidenceThresholdHeight)
+// PruneStates provides a mock function with given fields: fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates
+func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error) {
+	ret := _m.Called(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PruneStates")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64) error); ok {
-		r0 = rf(fromHeight, toHeight, evidenceThresholdHeight)
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) (uint64, error)); ok {
+		return rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	}
+	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) uint64); ok {
+		r0 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(uint64)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(int64, int64, int64, uint64) error); ok {
+		r1 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Save provides a mock function with given fields: _a0

--- a/state/mocks/store.go
+++ b/state/mocks/store.go
@@ -401,9 +401,9 @@ func (_m *Store) PruneABCIResponses(targetRetainHeight int64, forceCompact bool)
 	return r0, r1, r2
 }
 
-// PruneStates provides a mock function with given fields: fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates
-func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error) {
-	ret := _m.Called(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+// PruneStates provides a mock function with given fields: fromHeight, toHeight, evidenceThresholdHeight
+func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThresholdHeight int64) (uint64, error) {
+	ret := _m.Called(fromHeight, toHeight, evidenceThresholdHeight)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PruneStates")
@@ -411,17 +411,17 @@ func (_m *Store) PruneStates(fromHeight int64, toHeight int64, evidenceThreshold
 
 	var r0 uint64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) (uint64, error)); ok {
-		return rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	if rf, ok := ret.Get(0).(func(int64, int64, int64) (uint64, error)); ok {
+		return rf(fromHeight, toHeight, evidenceThresholdHeight)
 	}
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, uint64) uint64); ok {
-		r0 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	if rf, ok := ret.Get(0).(func(int64, int64, int64) uint64); ok {
+		r0 = rf(fromHeight, toHeight, evidenceThresholdHeight)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
-	if rf, ok := ret.Get(1).(func(int64, int64, int64, uint64) error); ok {
-		r1 = rf(fromHeight, toHeight, evidenceThresholdHeight, previouslyPrunedStates)
+	if rf, ok := ret.Get(1).(func(int64, int64, int64) error); ok {
+		r1 = rf(fromHeight, toHeight, evidenceThresholdHeight)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -37,6 +37,10 @@ type Pruner struct {
 	observer PrunerObserver
 
 	metrics *Metrics
+
+	// Preserve the number of state entries pruned.
+	// Used to calculated correctly when to trigger compactions
+	prunedStates uint64
 }
 
 type prunerConfig struct {
@@ -303,10 +307,16 @@ func (p *Pruner) pruneABCIResToRetainHeight(lastRetainHeight int64) int64 {
 		return lastRetainHeight
 	}
 
+	// If the block retain height is 0, pruning of the block and state stores might be disabled
+	// This should not prevent Comet from pruning ABCI results if needed.
+	// We could by default always compact when pruning the responses, but in case the state store
+	// is being compacted we introduce an overhead that might cause performance penalties.
+	forceCompact := p.findMinBlockRetainHeight() == 0
+
 	// newRetainHeight is the height just after that which we have successfully
 	// pruned. In case of an error it will be 0, but then it will also be
 	// ignored.
-	numPruned, newRetainHeight, err := p.stateStore.PruneABCIResponses(targetRetainHeight)
+	numPruned, newRetainHeight, err := p.stateStore.PruneABCIResponses(targetRetainHeight, forceCompact)
 	if err != nil {
 		p.logger.Error("Failed to prune ABCI responses", "err", err, "targetRetainHeight", targetRetainHeight)
 		return lastRetainHeight
@@ -357,8 +367,14 @@ func (p *Pruner) pruneBlocksToHeight(height int64) (uint64, int64, error) {
 	if err != nil {
 		return 0, 0, ErrFailedToPruneBlocks{Height: height, Err: err}
 	}
-	if err := p.stateStore.PruneStates(base, height, evRetainHeight); err != nil {
-		return 0, 0, ErrFailedToPruneStates{Height: height, Err: err}
+
+	if pruned > 0 {
+		prunedStates, err := p.stateStore.PruneStates(base, height, evRetainHeight, p.prunedStates)
+		p.prunedStates += prunedStates
+		if err != nil {
+			return 0, 0, ErrFailedToPruneStates{Height: height, Err: err}
+		}
+
 	}
 	return pruned, evRetainHeight, err
 }

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -369,12 +369,11 @@ func (p *Pruner) pruneBlocksToHeight(height int64) (uint64, int64, error) {
 	}
 
 	if pruned > 0 {
-		prunedStates, err := p.stateStore.PruneStates(base, height, evRetainHeight, p.prunedStates)
-		p.prunedStates += prunedStates
+
+		p.prunedStates, err = p.stateStore.PruneStates(base, height, evRetainHeight, p.prunedStates)
 		if err != nil {
 			return 0, 0, ErrFailedToPruneStates{Height: height, Err: err}
 		}
-
 	}
 	return pruned, evRetainHeight, err
 }

--- a/state/pruner.go
+++ b/state/pruner.go
@@ -40,6 +40,7 @@ type Pruner struct {
 
 	// Preserve the number of state entries pruned.
 	// Used to calculated correctly when to trigger compactions
+	// TODO This is unused and should be removed from V1 and main as well.
 	prunedStates uint64
 }
 
@@ -370,7 +371,7 @@ func (p *Pruner) pruneBlocksToHeight(height int64) (uint64, int64, error) {
 
 	if pruned > 0 {
 
-		p.prunedStates, err = p.stateStore.PruneStates(base, height, evRetainHeight, p.prunedStates)
+		_, err = p.stateStore.PruneStates(base, height, evRetainHeight)
 		if err != nil {
 			return 0, 0, ErrFailedToPruneStates{Height: height, Err: err}
 		}

--- a/state/store.go
+++ b/state/store.go
@@ -121,6 +121,10 @@ type StoreOptions struct {
 	Compact bool
 
 	CompactionInterval int64
+
+	ResultsToCompact uint64
+
+	StatesToCompact uint64
 }
 
 var _ Store = (*dbStore)(nil)
@@ -423,13 +427,17 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 	if err != nil {
 		return pruned, err
 	}
+	store.StoreOptions.StatesToCompact += uint64(pruned)
 
 	// We do not want to panic or interrupt consensus on compaction failure
-	if store.StoreOptions.Compact && previosulyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
+	if store.StoreOptions.Compact && store.StoreOptions.StatesToCompact >= uint64(store.StoreOptions.CompactionInterval) {
 		// When the range is nil,nil, the database will try to compact
 		// ALL levels. Another option is to set a predefined range of
 		// specific keys.
 		err = store.db.Compact(nil, nil)
+		if err == nil {
+			store.StoreOptions.StatesToCompact = 0
+		}
 	}
 
 	return pruned, nil
@@ -481,9 +489,11 @@ func (store dbStore) PruneABCIResponses(targetRetainHeight int64, forceCompact b
 		return pruned + batchPruned, targetRetainHeight, err
 	}
 
-	if forceCompact && store.Compact {
-		if pruned+batchPruned >= store.CompactionInterval || targetRetainHeight-lastRetainHeight >= store.CompactionInterval {
-			err = store.db.Compact(nil, nil)
+	store.StoreOptions.ResultsToCompact += uint64(pruned + batchPruned)
+	if forceCompact && store.Compact && store.StoreOptions.ResultsToCompact >= (uint64)(store.StoreOptions.CompactionInterval) {
+		err = store.db.Compact(nil, nil)
+		if err == nil {
+			store.StoreOptions.ResultsToCompact = 0
 		}
 	}
 	return pruned + batchPruned, targetRetainHeight, err

--- a/state/store.go
+++ b/state/store.go
@@ -109,8 +109,15 @@ type dbStore struct {
 	db dbm.DB
 
 	StoreOptions
+
+	StoreStateKeeper
 }
 
+type StoreStateKeeper struct {
+	ResultsToCompact uint64
+
+	StatesToCompact uint64
+}
 type StoreOptions struct {
 	// DiscardABCIResponses determines whether or not the store
 	// retains all ABCIResponses. If DiscardABCIResponses is enabled,
@@ -121,10 +128,6 @@ type StoreOptions struct {
 	Compact bool
 
 	CompactionInterval int64
-
-	ResultsToCompact uint64
-
-	StatesToCompact uint64
 }
 
 var _ Store = (*dbStore)(nil)
@@ -139,7 +142,7 @@ func IsEmpty(store dbStore) (bool, error) {
 
 // NewStore creates the dbStore of the state pkg.
 func NewStore(db dbm.DB, options StoreOptions) Store {
-	return dbStore{db, options}
+	return dbStore{db, options, StoreStateKeeper{}}
 }
 
 // LoadStateFromDBOrGenesisFile loads the most recent state from the database,
@@ -427,16 +430,18 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 	if err != nil {
 		return pruned, err
 	}
-	store.StoreOptions.StatesToCompact += uint64(pruned)
 
 	// We do not want to panic or interrupt consensus on compaction failure
-	if store.StoreOptions.Compact && store.StoreOptions.StatesToCompact >= uint64(store.StoreOptions.CompactionInterval) {
-		// When the range is nil,nil, the database will try to compact
-		// ALL levels. Another option is to set a predefined range of
-		// specific keys.
-		err = store.db.Compact(nil, nil)
-		if err == nil {
-			store.StoreOptions.StatesToCompact = 0
+	if store.StoreOptions.Compact {
+		store.StoreStateKeeper.StatesToCompact += uint64(pruned)
+		if store.StoreStateKeeper.StatesToCompact >= uint64(store.StoreOptions.CompactionInterval) {
+			// When the range is nil,nil, the database will try to compact
+			// ALL levels. Another option is to set a predefined range of
+			// specific keys.
+			err = store.db.Compact(nil, nil)
+			if err == nil {
+				store.StoreStateKeeper.StatesToCompact = 0
+			}
 		}
 	}
 
@@ -489,11 +494,17 @@ func (store dbStore) PruneABCIResponses(targetRetainHeight int64, forceCompact b
 		return pruned + batchPruned, targetRetainHeight, err
 	}
 
-	store.StoreOptions.ResultsToCompact += uint64(pruned + batchPruned)
-	if forceCompact && store.Compact && store.StoreOptions.ResultsToCompact >= (uint64)(store.StoreOptions.CompactionInterval) {
-		err = store.db.Compact(nil, nil)
-		if err == nil {
-			store.StoreOptions.ResultsToCompact = 0
+	// forceCompact was introduced because in main and v1 there is no config to prune ABCI results
+	// and they are pruned only when instructed by the data companion (which does not exist here)
+	// When we do want to enfore pruning of the results with state pruning then
+	// we can also check store.Compact
+	if forceCompact || store.StoreOptions.Compact {
+		store.StoreStateKeeper.ResultsToCompact += uint64(pruned + batchPruned)
+		if store.StoreStateKeeper.ResultsToCompact >= (uint64)(store.StoreOptions.CompactionInterval) {
+			err = store.db.Compact(nil, nil)
+			if err == nil {
+				store.StoreStateKeeper.ResultsToCompact = 0
+			}
 		}
 	}
 	return pruned + batchPruned, targetRetainHeight, err

--- a/state/store.go
+++ b/state/store.go
@@ -85,7 +85,7 @@ type Store interface {
 	// Gets the height at which the store is bootstrapped after out of band statesync
 	GetOfflineStateSyncHeight() (int64, error)
 	// PruneStates takes the height from which to start pruning and which height stop at
-	PruneStates(fromHeight, toHeight, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error)
+	PruneStates(fromHeight, toHeight, evidenceThresholdHeight int64) (uint64, error)
 	// PruneABCIResponses will prune all ABCI responses below the given height.
 	PruneABCIResponses(targetRetainHeight int64, forceCompact bool) (int64, int64, error)
 	// SaveApplicationRetainHeight persists the application retain height from the application
@@ -306,7 +306,7 @@ func (store dbStore) Bootstrap(state State) error {
 // encoding not preserving ordering: https://github.com/tendermint/tendermint/issues/4567
 // This will cause some old states to be left behind when doing incremental partial prunes,
 // specifically older checkpoints and LastHeightChanged targets.
-func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64, previosulyPrunedStates uint64) (uint64, error) {
+func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64) (uint64, error) {
 	if from <= 0 || to <= 0 {
 		return 0, fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
 	}

--- a/state/store.go
+++ b/state/store.go
@@ -85,9 +85,9 @@ type Store interface {
 	// Gets the height at which the store is bootstrapped after out of band statesync
 	GetOfflineStateSyncHeight() (int64, error)
 	// PruneStates takes the height from which to start pruning and which height stop at
-	PruneStates(fromHeight, toHeight, evidenceThresholdHeight int64) error
+	PruneStates(fromHeight, toHeight, evidenceThresholdHeight int64, previouslyPrunedStates uint64) (uint64, error)
 	// PruneABCIResponses will prune all ABCI responses below the given height.
-	PruneABCIResponses(targetRetainHeight int64) (int64, int64, error)
+	PruneABCIResponses(targetRetainHeight int64, forceCompact bool) (int64, int64, error)
 	// SaveApplicationRetainHeight persists the application retain height from the application
 	SaveApplicationRetainHeight(height int64) error
 	// GetApplicationRetainHeight returns the retain height set by the application
@@ -117,6 +117,10 @@ type StoreOptions struct {
 	// the store will maintain only the response object from the latest
 	// height.
 	DiscardABCIResponses bool
+
+	Compact bool
+
+	CompactionInterval int64
 }
 
 var _ Store = (*dbStore)(nil)
@@ -295,21 +299,21 @@ func (store dbStore) Bootstrap(state State) error {
 // encoding not preserving ordering: https://github.com/tendermint/tendermint/issues/4567
 // This will cause some old states to be left behind when doing incremental partial prunes,
 // specifically older checkpoints and LastHeightChanged targets.
-func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64) error {
+func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight int64, previosulyPrunedStates uint64) (uint64, error) {
 	if from <= 0 || to <= 0 {
-		return fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
+		return 0, fmt.Errorf("from height %v and to height %v must be greater than 0", from, to)
 	}
 	if from >= to {
-		return fmt.Errorf("from height %v must be lower than to height %v", from, to)
+		return 0, fmt.Errorf("from height %v must be lower than to height %v", from, to)
 	}
 
 	valInfo, err := loadValidatorsInfo(store.db, min(to, evidenceThresholdHeight))
 	if err != nil {
-		return fmt.Errorf("validators at height %v not found: %w", to, err)
+		return 0, fmt.Errorf("validators at height %v not found: %w", to, err)
 	}
 	paramsInfo, err := store.loadConsensusParamsInfo(to)
 	if err != nil {
-		return fmt.Errorf("consensus params at height %v not found: %w", to, err)
+		return 0, fmt.Errorf("consensus params at height %v not found: %w", to, err)
 	}
 
 	keepVals := make(map[int64]bool)
@@ -337,12 +341,12 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 			if err != nil || v.ValidatorSet == nil {
 				vip, err := store.LoadValidators(h)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				pvi, err := vip.ToProto()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				v.ValidatorSet = pvi
@@ -350,17 +354,17 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 
 				bz, err := v.Marshal()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 				err = batch.Set(calcValidatorsKey(h), bz)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 			}
 		} else if h < evidenceThresholdHeight {
 			err = batch.Delete(calcValidatorsKey(h))
 			if err != nil {
-				return err
+				return pruned, err
 			}
 		}
 		// else we keep the validator set because we might need
@@ -369,37 +373,37 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		if keepParams[h] {
 			p, err := store.loadConsensusParamsInfo(h)
 			if err != nil {
-				return err
+				return pruned, err
 			}
 
 			if p.ConsensusParams.Equal(&cmtproto.ConsensusParams{}) {
 				params, err := store.LoadConsensusParams(h)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 				p.ConsensusParams = params.ToProto()
 
 				p.LastHeightChanged = h
 				bz, err := p.Marshal()
 				if err != nil {
-					return err
+					return pruned, err
 				}
 
 				err = batch.Set(calcConsensusParamsKey(h), bz)
 				if err != nil {
-					return err
+					return pruned, err
 				}
 			}
 		} else {
 			err = batch.Delete(calcConsensusParamsKey(h))
 			if err != nil {
-				return err
+				return pruned, err
 			}
 		}
 
 		err = batch.Delete(calcABCIResponsesKey(h))
 		if err != nil {
-			return err
+			return pruned, err
 		}
 		pruned++
 
@@ -407,7 +411,7 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 		if pruned%1000 == 0 && pruned > 0 {
 			err := batch.Write()
 			if err != nil {
-				return err
+				return pruned, err
 			}
 			batch.Close()
 			batch = store.db.NewBatch()
@@ -417,16 +421,24 @@ func (store dbStore) PruneStates(from int64, to int64, evidenceThresholdHeight i
 
 	err = batch.WriteSync()
 	if err != nil {
-		return err
+		return pruned, err
 	}
 
-	return nil
+	// We do not want to panic or interrupt consensus on compaction failure
+	if store.StoreOptions.Compact && previosulyPrunedStates+pruned >= uint64(store.StoreOptions.CompactionInterval) {
+		// When the range is nil,nil, the database will try to compact
+		// ALL levels. Another option is to set a predefined range of
+		// specific keys.
+		err = store.db.Compact(nil, nil)
+	}
+
+	return pruned, nil
 }
 
 // PruneABCIResponses attempts to prune all ABCI responses up to, but not
 // including, the given height. On success, returns the number of heights
 // pruned and the new retain height.
-func (store dbStore) PruneABCIResponses(targetRetainHeight int64) (int64, int64, error) {
+func (store dbStore) PruneABCIResponses(targetRetainHeight int64, forceCompact bool) (int64, int64, error) {
 	if store.DiscardABCIResponses {
 		return 0, 0, nil
 	}
@@ -465,7 +477,16 @@ func (store dbStore) PruneABCIResponses(targetRetainHeight int64) (int64, int64,
 			defer batch.Close()
 		}
 	}
-	return pruned + batchPruned, targetRetainHeight, batch.WriteSync()
+	if err = batch.WriteSync(); err != nil {
+		return pruned + batchPruned, targetRetainHeight, err
+	}
+
+	if forceCompact && store.Compact {
+		if pruned+batchPruned >= store.CompactionInterval || targetRetainHeight-lastRetainHeight >= store.CompactionInterval {
+			err = store.db.Compact(nil, nil)
+		}
+	}
+	return pruned + batchPruned, targetRetainHeight, err
 }
 
 //------------------------------------------------------------------------

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -86,6 +86,53 @@ func BenchmarkLoadValidators(b *testing.B) {
 	}
 }
 
+func makeAndSaveStates(t *testing.T, fromHeight int64, toHeight int64, stateStore sm.Store) {
+
+	finalizeBlockResults := &abci.ResponseFinalizeBlock{
+		TxResults: []*abci.ExecTxResult{
+			{Data: []byte{1}},
+			{Data: []byte{2}},
+			{Data: []byte{3}},
+		},
+		AppHash: make([]byte, 1),
+	}
+
+	validatorSet := genValSet(1)
+
+	valsChanged := int64(0)
+	paramsChanged := int64(0)
+
+	for h := fromHeight; h <= toHeight; h++ {
+		if valsChanged == 0 || h%10 == 2 {
+			valsChanged = h + 1 // Have to add 1, since NextValidators is what's stored
+		}
+		if paramsChanged == 0 || h%10 == 5 {
+			paramsChanged = h
+		}
+
+		state := sm.State{
+			InitialHeight:   1,
+			LastBlockHeight: h - 1,
+			Validators:      validatorSet,
+			NextValidators:  validatorSet,
+			ConsensusParams: types.ConsensusParams{
+				Block: types.BlockParams{MaxBytes: 10e6},
+			},
+			LastHeightValidatorsChanged:      valsChanged,
+			LastHeightConsensusParamsChanged: paramsChanged,
+		}
+
+		if state.LastBlockHeight >= 1 {
+			state.LastValidators = state.Validators
+		}
+
+		err := stateStore.Save(state)
+		require.NoError(t, err)
+
+		err = stateStore.SaveFinalizeBlockResponse(h, finalizeBlockResults)
+		require.NoError(t, err)
+	}
+}
 func TestPruneStates(t *testing.T) {
 	testcases := map[string]struct {
 		makeHeights             int64
@@ -117,14 +164,6 @@ func TestPruneStates(t *testing.T) {
 		"prune when evidence height < height": {20, 1, 18, 17, false, []int64{13, 17, 18, 19, 20}, []int64{15, 18, 19, 20}, []int64{18, 19, 20}},
 	}
 
-	finalizeBlockResults := &abci.ResponseFinalizeBlock{
-		TxResults: []*abci.ExecTxResult{
-			{Data: []byte{1}},
-			{Data: []byte{2}},
-			{Data: []byte{3}},
-		},
-		AppHash: make([]byte, 1),
-	}
 	for name, tc := range testcases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
@@ -133,41 +172,7 @@ func TestPruneStates(t *testing.T) {
 
 			// Generate a bunch of state data. Validators change for heights ending with 3, and
 			// parameters when ending with 5.
-			validatorSet := genValSet(1)
-
-			valsChanged := int64(0)
-			paramsChanged := int64(0)
-
-			for h := int64(1); h <= tc.makeHeights; h++ {
-				if valsChanged == 0 || h%10 == 2 {
-					valsChanged = h + 1 // Have to add 1, since NextValidators is what's stored
-				}
-				if paramsChanged == 0 || h%10 == 5 {
-					paramsChanged = h
-				}
-
-				state := sm.State{
-					InitialHeight:   1,
-					LastBlockHeight: h - 1,
-					Validators:      validatorSet,
-					NextValidators:  validatorSet,
-					ConsensusParams: types.ConsensusParams{
-						Block: types.BlockParams{MaxBytes: 10e6},
-					},
-					LastHeightValidatorsChanged:      valsChanged,
-					LastHeightConsensusParamsChanged: paramsChanged,
-				}
-
-				if state.LastBlockHeight >= 1 {
-					state.LastValidators = state.Validators
-				}
-
-				err := stateStore.Save(state)
-				require.NoError(t, err)
-
-				err = stateStore.SaveFinalizeBlockResponse(h, finalizeBlockResults)
-				require.NoError(t, err)
-			}
+			makeAndSaveStates(t, 1, tc.makeHeights, stateStore)
 
 			// Test assertions
 			_, err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight, 0)
@@ -245,6 +250,8 @@ func makeStateAndBlockStore(testName string) (sm.State, *store.BlockStore, func(
 	stateDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: false,
+		Compact:              true,
+		CompactionInterval:   1,
 	})
 	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
 	if err != nil {

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -175,7 +175,7 @@ func TestPruneStates(t *testing.T) {
 			makeAndSaveStates(t, 1, tc.makeHeights, stateStore)
 
 			// Test assertions
-			_, err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight, 0)
+			_, err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight)
 			if tc.expectErr {
 				require.Error(t, err)
 				return

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -175,7 +175,7 @@ func TestPruneStates(t *testing.T) {
 			}
 
 			// Test assertions
-			err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight)
+			_, err := stateStore.PruneStates(tc.pruneFrom, tc.pruneTo, tc.evidenceThresholdHeight, 0)
 			if tc.expectErr {
 				require.Error(t, err)
 				return

--- a/store/store.go
+++ b/store/store.go
@@ -60,17 +60,36 @@ type BlockStore struct {
 	seenCommitCache          *lru.Cache[int64, *types.Commit]
 	blockCommitCache         *lru.Cache[int64, *types.Commit]
 	blockExtendedCommitCache *lru.Cache[int64, *types.ExtendedCommit]
+
+	blocksDeleted      int64
+	compact            bool
+	compactionInterval int64
+}
+
+type BlockStoreOption func(*BlockStore)
+
+// WithCompaction sets the compaciton parameters.
+func WithCompaction(compact bool, compactionInterval int64) BlockStoreOption {
+	return func(bs *BlockStore) {
+		bs.compact = compact
+		bs.compactionInterval = compactionInterval
+	}
 }
 
 // NewBlockStore returns a new BlockStore with the given DB,
 // initialized to the last height that was committed to the DB.
-func NewBlockStore(db dbm.DB) *BlockStore {
+func NewBlockStore(db dbm.DB, options ...BlockStoreOption) *BlockStore {
+
 	bs := LoadBlockStoreState(db)
 	bStore := &BlockStore{
 		base:   bs.Base,
 		height: bs.Height,
 		db:     db,
 	}
+	for _, option := range options {
+		option(bStore)
+	}
+
 	bStore.addCaches()
 	return bStore
 }
@@ -430,7 +449,21 @@ func (bs *BlockStore) PruneBlocks(height int64, state sm.State) (uint64, int64, 
 	if err != nil {
 		return 0, -1, err
 	}
-	return pruned, evidencePoint, nil
+	bs.blocksDeleted += int64(pruned)
+
+	if bs.compact && bs.blocksDeleted >= bs.compactionInterval {
+		// When the range is nil,nil, the database will try to compact
+		// ALL levels. Another option is to set a predefined range of
+		// specific keys.
+		err = bs.db.Compact(nil, nil)
+		if err == nil {
+			// If there was no error in compaction we reset the counter.
+			// Otherwise we preserve the number of blocks deleted so
+			// we can trigger compaction in the next pruning iteration
+			bs.blocksDeleted = 0
+		}
+	}
+	return pruned, evidencePoint, err
 }
 
 // SaveBlock persists the given block, blockParts, and seenCommit to the underlying db.


### PR DESCRIPTION
This is a manual back port of https://github.com/cometbft/cometbft/pull/2356/files#diff-fe3f53c9e61cbc76a2639c55769478a908fe350e272b241250b50489ebc38568 . I copied the changes  to not include indexer related things as the indexer pruning is not existing yet in the target branch. 



---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
